### PR TITLE
configurable cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -230,6 +230,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.11.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/digitalocean/godo v1.7.5 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
@@ -331,6 +332,7 @@ require (
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
+	github.com/redis/go-redis/v9 v9.11.0 // indirect
 	github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -158,6 +158,10 @@ github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dR
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boombuler/barcode v1.0.1 h1:NDBbPmhS+EqABEs5Kg3n/5ZNjy73Pz7SIV+KCeqyXcs=
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
 github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZlaQsNA=
 github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp+BagBSZWx+TP8=
 github.com/caddyserver/certmagic v0.23.0 h1:CfpZ/50jMfG4+1J/u2LV6piJq4HOfO6ppOnOf7DkFEU=
@@ -205,6 +209,8 @@ github.com/denverdino/aliyungo v0.0.0-20170926055100-d3308649c661/go.mod h1:dV8l
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba h1:p6poVbjHDkKa+wtC8frBMwQtT3BmqGYBjzMwJ63tuR4=
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/digitalocean/godo v1.7.5 h1:JOQbAO6QT1GGjor0doT0mXefX2FgUDPOpYh2RaXA+ko=
 github.com/digitalocean/godo v1.7.5/go.mod h1:h6faOIcZ8lWIwNQ+DN7b3CgX4Kwby5T+nbpNqkUIozU=
@@ -841,6 +847,8 @@ github.com/rabbitmq/amqp091-go v1.10.0 h1:STpn5XsHlHGcecLmMFCtg7mqq0RnD+zFr4uzuk
 github.com/rabbitmq/amqp091-go v1.10.0/go.mod h1:Hy4jKW5kQART1u+JkDTF9YYOQUHXqMuhrgxOEeS7G4o=
 github.com/rboyer/safeio v0.2.3 h1:gUybicx1kp8nuM4vO0GA5xTBX58/OBd8MQuErBfDxP8=
 github.com/rboyer/safeio v0.2.3/go.mod h1:d7RMmt7utQBJZ4B7f0H/cU/EdZibQAU1Y8NWepK2dS8=
+github.com/redis/go-redis/v9 v9.11.0 h1:E3S08Gl/nJNn5vkxd2i78wZxWAPNZgUNTp8WIJUAiIs=
+github.com/redis/go-redis/v9 v9.11.0/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=
 github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03 h1:Wdi9nwnhFNAlseAOekn6B5G/+GMtks9UKbvRU/CMM/o=
 github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03/go.mod h1:gRAiPF5C5Nd0eyyRdqIu9qTiFSoZzpTq727b5B8fkkU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -63,6 +63,8 @@ require (
 require (
 	cel.dev/expr v0.23.1 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	golang.org/x/exp v0.0.0-20250606033433-dcc06ee1d476 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250324211829-b45e905df463 // indirect
@@ -107,6 +109,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/redis/go-redis/v9 v9.11.0
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -29,6 +29,8 @@ github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
@@ -37,6 +39,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/docker v27.4.1+incompatible h1:ZJvcY7gfwHn1JF48PfbyXg7Jyt9ZCWDW+GGXOIxEwp4=
@@ -254,6 +258,8 @@ github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8b
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
+github.com/redis/go-redis/v9 v9.11.0 h1:E3S08Gl/nJNn5vkxd2i78wZxWAPNZgUNTp8WIJUAiIs=
+github.com/redis/go-redis/v9 v9.11.0/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkBk=

--- a/sdk/helper/cache/cache.go
+++ b/sdk/helper/cache/cache.go
@@ -1,0 +1,69 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cache
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+// CacheBackend defines a generic interface for cache implementations
+type CacheBackend[K comparable, V any] interface {
+	// Get retrieves a value from the cache by key
+	Get(key K) (V, bool)
+
+	// Set stores a value in the cache
+	Set(key K, value V)
+
+	// Remove removes a value from the cache by key
+	Remove(key K)
+
+	// Purge clears all entries from the cache
+	Purge()
+
+	// Len returns the number of entries in the cache
+	Len() int
+}
+
+// CacheBackendType represents the type of cache backend
+type CacheBackendType string
+
+const (
+	CacheBackendLRU   CacheBackendType = "lru"
+	CacheBackendRedis CacheBackendType = "redis"
+)
+
+// Environment variable to control cache backend
+const CacheBackendEnvVar = "CACHE_BACKEND"
+
+// GetCacheBackendType returns the cache backend type from environment variable
+func GetCacheBackendType() CacheBackendType {
+	cacheType := strings.ToLower(strings.TrimSpace(os.Getenv(CacheBackendEnvVar)))
+	switch cacheType {
+	case string(CacheBackendRedis):
+		return CacheBackendRedis
+	case string(CacheBackendLRU), "":
+		return CacheBackendLRU
+	default:
+		return CacheBackendLRU
+	}
+}
+
+// Helper functions for environment variables
+func GetEnvOrDefault(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
+}
+
+func GetEnvIntOrDefault(key string, defaultValue int) int {
+	if value := os.Getenv(key); value != "" {
+		if intValue, err := strconv.Atoi(value); err == nil {
+			return intValue
+		}
+	}
+	return defaultValue
+}

--- a/sdk/helper/cache/cache_factory.go
+++ b/sdk/helper/cache/cache_factory.go
@@ -1,0 +1,24 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cache
+
+// NewCacheBackend creates a cache backend based on environment variables
+func NewCacheBackend[K comparable, V any](size int) (CacheBackend[K, V], error) {
+	cacheType := GetCacheBackendType()
+
+	switch cacheType {
+	case CacheBackendRedis:
+		return NewRedisCacheBackend[K, V](RedisConfig{
+			Addr:       GetEnvOrDefault("REDIS_ADDR", "localhost:6379"),
+			Password:   GetEnvOrDefault("REDIS_PASSWORD", ""),
+			DB:         GetEnvIntOrDefault("REDIS_DB", 0),
+			KeyPrefix:  GetEnvOrDefault("REDIS_KEY_PREFIX", ""),
+			DefaultTTL: 0, // No TTL by default
+		})
+	case CacheBackendLRU:
+		fallthrough
+	default:
+		return NewLRUCacheBackend[K, V](size)
+	}
+}

--- a/sdk/helper/cache/cache_factory.go
+++ b/sdk/helper/cache/cache_factory.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package cache
 
 // NewCacheBackend creates a cache backend based on environment variables

--- a/sdk/helper/cache/cache_lru.go
+++ b/sdk/helper/cache/cache_lru.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package cache
 
 import (

--- a/sdk/helper/cache/cache_lru.go
+++ b/sdk/helper/cache/cache_lru.go
@@ -1,0 +1,42 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cache
+
+import (
+	lru "github.com/hashicorp/golang-lru/v2"
+)
+
+// LRUCacheBackend implements CacheBackend using the LRU cache
+type LRUCacheBackend[K comparable, V any] struct {
+	cache *lru.TwoQueueCache[K, V]
+}
+
+// NewLRUCacheBackend creates a new LRU cache backend
+func NewLRUCacheBackend[K comparable, V any](size int) (*LRUCacheBackend[K, V], error) {
+	cache, err := lru.New2Q[K, V](size)
+	if err != nil {
+		return nil, err
+	}
+	return &LRUCacheBackend[K, V]{cache: cache}, nil
+}
+
+func (l *LRUCacheBackend[K, V]) Get(key K) (V, bool) {
+	return l.cache.Get(key)
+}
+
+func (l *LRUCacheBackend[K, V]) Set(key K, value V) {
+	l.cache.Add(key, value)
+}
+
+func (l *LRUCacheBackend[K, V]) Remove(key K) {
+	l.cache.Remove(key)
+}
+
+func (l *LRUCacheBackend[K, V]) Purge() {
+	l.cache.Purge()
+}
+
+func (l *LRUCacheBackend[K, V]) Len() int {
+	return l.cache.Len()
+}

--- a/sdk/helper/cache/cache_redis.go
+++ b/sdk/helper/cache/cache_redis.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package cache
 
 import (

--- a/sdk/helper/cache/cache_redis.go
+++ b/sdk/helper/cache/cache_redis.go
@@ -1,0 +1,102 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// RedisConfig holds configuration for Redis cache backend
+type RedisConfig struct {
+	Addr       string
+	Password   string
+	DB         int
+	KeyPrefix  string
+	DefaultTTL time.Duration
+}
+
+// RedisCacheBackend implements CacheBackend using Redis
+type RedisCacheBackend[K comparable, V any] struct {
+	client     *redis.Client
+	ctx        context.Context
+	keyPrefix  string
+	defaultTTL time.Duration
+}
+
+// NewRedisCacheBackend creates a new Redis cache backend
+func NewRedisCacheBackend[K comparable, V any](cfg RedisConfig) (*RedisCacheBackend[K, V], error) {
+	client := redis.NewClient(&redis.Options{
+		Addr:     cfg.Addr,
+		Password: cfg.Password,
+		DB:       cfg.DB,
+	})
+	return &RedisCacheBackend[K, V]{
+		client:     client,
+		ctx:        context.Background(),
+		keyPrefix:  cfg.KeyPrefix,
+		defaultTTL: cfg.DefaultTTL,
+	}, nil
+}
+
+func (r *RedisCacheBackend[K, V]) redisKey(key K) string {
+	keyStr := toString(key)
+	if r.keyPrefix != "" {
+		return r.keyPrefix + keyStr
+	}
+	return keyStr
+}
+
+func (r *RedisCacheBackend[K, V]) Get(key K) (V, bool) {
+	var zero V
+	data, err := r.client.Get(r.ctx, r.redisKey(key)).Bytes()
+	if err != nil {
+		if err == redis.Nil {
+			return zero, false
+		}
+		return zero, false
+	}
+
+	var value V
+	if err := json.Unmarshal(data, &value); err != nil {
+		return zero, false
+	}
+	return value, true
+}
+
+func (r *RedisCacheBackend[K, V]) Set(key K, value V) {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return
+	}
+	r.client.Set(r.ctx, r.redisKey(key), data, r.defaultTTL)
+}
+
+func (r *RedisCacheBackend[K, V]) Remove(key K) {
+	r.client.Del(r.ctx, r.redisKey(key))
+}
+
+func (r *RedisCacheBackend[K, V]) Purge() {
+	// WARNING: This deletes all keys in the current DB. Use with caution.
+	r.client.FlushDB(r.ctx)
+}
+
+func (r *RedisCacheBackend[K, V]) Len() int {
+	size, err := r.client.DBSize(r.ctx).Result()
+	if err != nil {
+		return 0
+	}
+	return int(size)
+}
+
+// toString converts any comparable type to string for Redis key
+func toString[K comparable](key K) string {
+	// For now, we'll use JSON marshaling as a generic approach
+	// This could be optimized for specific types if needed
+	data, _ := json.Marshal(key)
+	return string(data)
+}

--- a/sdk/helper/keysutil/encrypted_key_storage.go
+++ b/sdk/helper/keysutil/encrypted_key_storage.go
@@ -12,7 +12,7 @@ import (
 	"sort"
 	"strings"
 
-	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/openbao/openbao/sdk/v2/helper/cache"
 	"github.com/openbao/openbao/sdk/v2/logical"
 )
 
@@ -96,7 +96,7 @@ func NewEncryptedKeyStorageWrapper(config EncryptedKeyStorageConfig) (*Encrypted
 		size = DefaultCacheSize
 	}
 
-	cache, err := lru.New2Q[string, string](size)
+	cacheBackend, err := cache.NewCacheBackend[string, string](size)
 	if err != nil {
 		return nil, err
 	}
@@ -104,13 +104,13 @@ func NewEncryptedKeyStorageWrapper(config EncryptedKeyStorageConfig) (*Encrypted
 	return &EncryptedKeyStorageWrapper{
 		policy: config.Policy,
 		prefix: config.Prefix,
-		lru:    cache,
+		cache:  cacheBackend,
 	}, nil
 }
 
 type EncryptedKeyStorageWrapper struct {
 	policy *Policy
-	lru    *lru.TwoQueueCache[string, string]
+	cache  cache.CacheBackend[string, string]
 	prefix string
 }
 
@@ -119,7 +119,7 @@ func (f *EncryptedKeyStorageWrapper) Wrap(s logical.Storage) logical.Storage {
 		policy: f.policy,
 		s:      s,
 		prefix: f.prefix,
-		lru:    f.lru,
+		cache:  f.cache,
 	}
 
 	if _, ok := s.(logical.TransactionalStorage); ok {
@@ -136,7 +136,7 @@ func (f *EncryptedKeyStorageWrapper) Wrap(s logical.Storage) logical.Storage {
 type encryptedKeyStorage struct {
 	policy *Policy
 	s      logical.Storage
-	lru    *lru.TwoQueueCache[string, string]
+	cache  cache.CacheBackend[string, string]
 
 	prefix string
 }
@@ -196,7 +196,7 @@ func (s *encryptedKeyStorage) ListPage(ctx context.Context, prefix string, after
 	context := []byte(paths.Join(s.prefix, prefix))
 
 	for i, k := range keys {
-		raw, ok := s.lru.Get(k)
+		raw, ok := s.cache.Get(k)
 		if ok {
 			// cache HIT, we can bail early and skip the decode & decrypt operations.
 			decryptedKeys[i] = raw
@@ -239,7 +239,7 @@ func (s *encryptedKeyStorage) ListPage(ctx context.Context, prefix string, after
 
 		// We want to store the unencoded version of the key in the cache.
 		// This will make it more performent when it's a HIT.
-		s.lru.Add(k, plaintext)
+		s.cache.Set(k, plaintext)
 
 		decryptedKeys[i] = plaintext
 	}
@@ -343,7 +343,7 @@ func (t *transactionalEncryptedKeyStorage) BeginReadOnlyTx(ctx context.Context) 
 		encryptedKeyStorage{
 			policy: t.encryptedKeyStorage.policy,
 			s:      tx,
-			lru:    t.encryptedKeyStorage.lru,
+			cache:  t.encryptedKeyStorage.cache,
 			prefix: t.encryptedKeyStorage.prefix,
 		},
 	}, nil
@@ -359,7 +359,7 @@ func (t *transactionalEncryptedKeyStorage) BeginTx(ctx context.Context) (logical
 		encryptedKeyStorage{
 			policy: t.encryptedKeyStorage.policy,
 			s:      tx,
-			lru:    t.encryptedKeyStorage.lru,
+			cache:  t.encryptedKeyStorage.cache,
 			prefix: t.encryptedKeyStorage.prefix,
 		},
 	}, nil

--- a/sdk/physical/cache.go
+++ b/sdk/physical/cache.go
@@ -10,7 +10,7 @@ import (
 
 	metrics "github.com/armon/go-metrics"
 	log "github.com/hashicorp/go-hclog"
-	lru "github.com/hashicorp/golang-lru/v2"
+	helpercache "github.com/openbao/openbao/sdk/v2/helper/cache"
 	"github.com/openbao/openbao/sdk/v2/helper/locksutil"
 	"github.com/openbao/openbao/sdk/v2/helper/pathmanager"
 )
@@ -45,9 +45,53 @@ var cacheExceptionsPaths = []string{
 }
 
 // CacheRefreshContext returns a context with an added value denoting if the
-// cache should attempt a refresh.
+// cache should be refreshed.
 func CacheRefreshContext(ctx context.Context, r bool) context.Context {
 	return context.WithValue(ctx, refreshCacheCtxKey, r)
+}
+
+// CacheBackend defines the interface for different cache implementations
+// This is now an adapter that wraps the generic helper cache
+type CacheBackend interface {
+	// Get retrieves an entry from the cache by key
+	Get(key string) (*Entry, bool)
+
+	// Set stores an entry in the cache
+	Set(key string, entry *Entry)
+
+	// Remove removes an entry from the cache by key
+	Remove(key string)
+
+	// Purge clears all entries from the cache
+	Purge()
+
+	// Len returns the number of entries in the cache
+	Len() int
+}
+
+// cacheBackendAdapter adapts the generic helper cache to the physical cache interface
+type cacheBackendAdapter struct {
+	cache helpercache.CacheBackend[string, *Entry]
+}
+
+func (a *cacheBackendAdapter) Get(key string) (*Entry, bool) {
+	return a.cache.Get(key)
+}
+
+func (a *cacheBackendAdapter) Set(key string, entry *Entry) {
+	a.cache.Set(key, entry)
+}
+
+func (a *cacheBackendAdapter) Remove(key string) {
+	a.cache.Remove(key)
+}
+
+func (a *cacheBackendAdapter) Purge() {
+	a.cache.Purge()
+}
+
+func (a *cacheBackendAdapter) Len() int {
+	return a.cache.Len()
 }
 
 // cacheRefreshFromContext is a helper to look up if the provided context is
@@ -77,7 +121,7 @@ type TransactionalCache interface {
 type cache struct {
 	backend         Backend
 	size            int
-	lru             *lru.TwoQueueCache[string, *Entry]
+	cacheBackend    CacheBackend
 	locks           []*locksutil.LockEntry
 	logger          log.Logger
 	enabled         *uint32
@@ -129,13 +173,13 @@ func newCache(b Backend, size int, logger log.Logger, metricSink metrics.MetricS
 	pm := pathmanager.New()
 	pm.AddPaths(cacheExceptionsPaths)
 
-	lruCache, _ := lru.New2Q[string, *Entry](size)
+	cacheBackend := createCacheBackendFromEnv(size, logger)
 	c := &cache{
-		backend: b,
-		size:    size,
-		lru:     lruCache,
-		locks:   locksutil.CreateLocks(),
-		logger:  logger,
+		backend:      b,
+		size:         size,
+		cacheBackend: cacheBackend,
+		locks:        locksutil.CreateLocks(),
+		logger:       logger,
 		// This fails safe.
 		enabled:         new(uint32),
 		cacheExceptions: pm,
@@ -181,7 +225,7 @@ func (c *cache) Purge(ctx context.Context) {
 		defer lock.Unlock()
 	}
 
-	c.lru.Purge()
+	c.cacheBackend.Purge()
 }
 
 // modifications to this function should also be applied to cacheTransaction.
@@ -210,7 +254,7 @@ func (c *cache) Put(ctx context.Context, entry *Entry) error {
 			cacheEntry.ValueHash = make([]byte, len(entry.ValueHash))
 			copy(cacheEntry.ValueHash, entry.ValueHash)
 		}
-		c.lru.Add(entry.Key, cacheEntry)
+		c.cacheBackend.Set(entry.Key, cacheEntry)
 		c.metricSink.IncrCounter([]string{"cache", "write"}, 1)
 	}
 	return err
@@ -225,9 +269,9 @@ func (c *cache) Get(ctx context.Context, key string) (*Entry, error) {
 	lock.RLock()
 	defer lock.RUnlock()
 
-	// Check the LRU first
+	// Check the cache first
 	if !cacheRefreshFromContext(ctx) {
-		if raw, ok := c.lru.Get(key); ok {
+		if raw, ok := c.cacheBackend.Get(key); ok {
 			if raw == nil {
 				return nil, nil
 			}
@@ -244,7 +288,7 @@ func (c *cache) Get(ctx context.Context, key string) (*Entry, error) {
 	}
 
 	// Cache the result, even if nil
-	c.lru.Add(key, ent)
+	c.cacheBackend.Set(key, ent)
 
 	return ent, nil
 }
@@ -261,7 +305,7 @@ func (c *cache) Delete(ctx context.Context, key string) error {
 
 	err := c.backend.Delete(ctx, key)
 	if err == nil {
-		c.lru.Remove(key)
+		c.cacheBackend.Remove(key)
 	}
 	return err
 }
@@ -346,7 +390,7 @@ func (c *cacheTransaction) Put(ctx context.Context, entry *Entry) error {
 			cacheEntry.ValueHash = make([]byte, len(entry.ValueHash))
 			copy(cacheEntry.ValueHash, entry.ValueHash)
 		}
-		c.lru.Add(entry.Key, cacheEntry)
+		c.cacheBackend.Set(entry.Key, cacheEntry)
 		c.modifiedLock.Lock()
 		c.modified[entry.Key] = struct{}{}
 		c.modifiedLock.Unlock()
@@ -370,7 +414,7 @@ func (c *cacheTransaction) Delete(ctx context.Context, key string) error {
 		c.modified[key] = struct{}{}
 		c.modifiedLock.Unlock()
 
-		c.lru.Remove(key)
+		c.cacheBackend.Remove(key)
 	}
 	return err
 }
@@ -394,7 +438,7 @@ func (c *cacheTransaction) Commit(ctx context.Context) error {
 			lock.Lock()
 			defer lock.Unlock()
 
-			c.parent.(*transactionalCache).lru.Remove(key)
+			c.parent.(*transactionalCache).cacheBackend.Remove(key)
 		}()
 	}
 	c.modifiedLock.Unlock()
@@ -411,4 +455,24 @@ func (c *cacheTransaction) Rollback(ctx context.Context) error {
 	// the underlying storage at all.
 
 	return nil
+}
+
+// NewDefaultCacheBackend creates the default cache backend implementation
+func NewDefaultCacheBackend(size int) CacheBackend {
+	genericCache, err := helpercache.NewCacheBackend[string, *Entry](size)
+	if err != nil {
+		// Fallback to a reasonable size if the requested size fails
+		genericCache, _ = helpercache.NewCacheBackend[string, *Entry](DefaultCacheSize)
+	}
+	return &cacheBackendAdapter{cache: genericCache}
+}
+
+// createCacheBackendFromEnv creates a cache backend based on environment variable
+func createCacheBackendFromEnv(size int, logger log.Logger) CacheBackend {
+	genericCache, err := helpercache.NewCacheBackend[string, *Entry](size)
+	if err != nil {
+		logger.Warn("failed to create cache backend, falling back to no cache", "error", err)
+		return nil
+	}
+	return &cacheBackendAdapter{cache: genericCache}
 }

--- a/sdk/physical/cache.go
+++ b/sdk/physical/cache.go
@@ -173,7 +173,7 @@ func newCache(b Backend, size int, logger log.Logger, metricSink metrics.MetricS
 	pm := pathmanager.New()
 	pm.AddPaths(cacheExceptionsPaths)
 
-	cacheBackend := createCacheBackendFromEnv(size, logger)
+	cacheBackend := createCacheBackend(size, logger)
 	c := &cache{
 		backend:      b,
 		size:         size,
@@ -457,18 +457,8 @@ func (c *cacheTransaction) Rollback(ctx context.Context) error {
 	return nil
 }
 
-// NewDefaultCacheBackend creates the default cache backend implementation
-func NewDefaultCacheBackend(size int) CacheBackend {
-	genericCache, err := helpercache.NewCacheBackend[string, *Entry](size)
-	if err != nil {
-		// Fallback to a reasonable size if the requested size fails
-		genericCache, _ = helpercache.NewCacheBackend[string, *Entry](DefaultCacheSize)
-	}
-	return &cacheBackendAdapter{cache: genericCache}
-}
-
-// createCacheBackendFromEnv creates a cache backend based on environment variable
-func createCacheBackendFromEnv(size int, logger log.Logger) CacheBackend {
+// createCacheBackend creates a cache backend using the helper cache
+func createCacheBackend(size int, logger log.Logger) CacheBackend {
 	genericCache, err := helpercache.NewCacheBackend[string, *Entry](size)
 	if err != nil {
 		logger.Warn("failed to create cache backend, falling back to no cache", "error", err)

--- a/test_vault_redis.go
+++ b/test_vault_redis.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+func main() {
+	fmt.Println("=== Vault Redis Cache Test ===")
+	fmt.Println()
+
+	// Check if Redis is available
+	if os.Getenv("REDIS_ADDR") == "" {
+		fmt.Println("❌ REDIS_ADDR environment variable not set")
+		fmt.Println("Please set REDIS_ADDR to your Redis server address")
+		fmt.Println("Example: export REDIS_ADDR=localhost:6379")
+		os.Exit(1)
+	}
+
+	// Check if Vault binary is available
+	vaultPath := findVaultBinary()
+	if vaultPath == "" {
+		fmt.Println("❌ Vault binary not found")
+		fmt.Println("Please ensure Vault is installed and available in PATH")
+		os.Exit(1)
+	}
+
+	fmt.Printf("✅ Found Vault binary: %s\n", vaultPath)
+	fmt.Printf("✅ Redis address: %s\n", os.Getenv("REDIS_ADDR"))
+	fmt.Println()
+
+	// Create temporary directory for Vault data
+	tempDir, err := os.MkdirTemp("", "vault-redis-test-*")
+	if err != nil {
+		log.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	vaultDataDir := filepath.Join(tempDir, "vault-data")
+	os.MkdirAll(vaultDataDir, 0755)
+
+	// Create Vault configuration file
+	configPath := filepath.Join(tempDir, "vault.hcl")
+	configContent := fmt.Sprintf(`
+storage "file" {
+  path = "%s"
+}
+
+listener "tcp" {
+  address = "127.0.0.1:9200"
+  tls_disable = 1
+}
+
+# Cache backend will be selected via environment variables
+# CACHE_BACKEND=redis for Redis, or omit for LRU
+`, vaultDataDir)
+
+	err = os.WriteFile(configPath, []byte(configContent), 0644)
+	if err != nil {
+		log.Fatalf("Failed to write config file: %v", err)
+	}
+
+	fmt.Printf("✅ Created Vault config: %s\n", configPath)
+	fmt.Println()
+
+	// Set environment variables for Redis cache
+	env := os.Environ()
+	env = append(env, "CACHE_BACKEND=redis")
+	env = append(env, "REDIS_ADDR="+os.Getenv("REDIS_ADDR"))
+	if redisPassword := os.Getenv("REDIS_PASSWORD"); redisPassword != "" {
+		env = append(env, "REDIS_PASSWORD="+redisPassword)
+	}
+	if redisDB := os.Getenv("REDIS_DB"); redisDB != "" {
+		env = append(env, "REDIS_DB="+redisDB)
+	}
+
+	// Start Vault server
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, vaultPath, "server", "-dev", "-dev-root-token-id=dev-only-token", "-config="+configPath)
+	cmd.Env = env
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	fmt.Println("🚀 Starting Vault server with Redis cache...")
+	fmt.Println("Environment variables:")
+	fmt.Printf("  CACHE_BACKEND=%s\n", os.Getenv("CACHE_BACKEND"))
+	fmt.Printf("  REDIS_ADDR=%s\n", os.Getenv("REDIS_ADDR"))
+	fmt.Printf("  REDIS_PASSWORD=%s\n", os.Getenv("REDIS_PASSWORD"))
+	fmt.Printf("  REDIS_DB=%s\n", os.Getenv("REDIS_DB"))
+	fmt.Println()
+
+	err = cmd.Start()
+	if err != nil {
+		log.Fatalf("Failed to start Vault server: %v", err)
+	}
+
+	// Wait for Vault to start
+	fmt.Println("⏳ Waiting for Vault server to start...")
+	time.Sleep(5 * time.Second)
+
+	// Test Vault API
+	fmt.Println("🔍 Testing Vault API...")
+	testVaultAPI()
+
+	// Keep server running for a bit to demonstrate
+	fmt.Println("⏳ Keeping Vault server running for 10 seconds to demonstrate...")
+	fmt.Println("Press Ctrl+C to stop early")
+
+	// Set up signal handling for graceful shutdown
+	go func() {
+		time.Sleep(10 * time.Second)
+		fmt.Println("🛑 Stopping Vault server...")
+		cancel()
+	}()
+
+	// Wait for server to stop
+	cmd.Wait()
+	fmt.Println("✅ Vault server stopped")
+}
+
+func testVaultAPI() {
+	// Test basic Vault API functionality
+	client := &http.Client{Timeout: 10 * time.Second}
+
+	// Test health endpoint
+	resp, err := client.Get("http://127.0.0.1:8200/v1/sys/health")
+	if err != nil {
+		fmt.Printf("❌ Vault server not responding: %v\n", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		fmt.Println("✅ Vault server is responding")
+	} else {
+		fmt.Printf("⚠️  Vault server responded with status: %d\n", resp.StatusCode)
+	}
+
+	// Test initialization status
+	resp, err = client.Get("http://127.0.0.1:8200/v1/sys/init")
+	if err != nil {
+		fmt.Printf("❌ Failed to check initialization: %v\n", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		fmt.Println("✅ Vault initialization endpoint responding")
+	} else {
+		fmt.Printf("⚠️  Initialization endpoint status: %d\n", resp.StatusCode)
+	}
+}
+
+// Helper function to find Vault binary
+func findVaultBinary() string {
+	// Check common locations
+	paths := []string{
+		"bao",
+		"./bao",
+		"../bao",
+		"../../bao",
+		"../../../bao",
+		"./bin/bao",
+	}
+
+	// Check PATH
+	for _, path := range paths {
+		if _, err := exec.LookPath(path); err == nil {
+			return path
+		}
+	}
+
+	return ""
+}

--- a/test_vault_redis.go
+++ b/test_vault_redis.go
@@ -43,7 +43,7 @@ func main() {
 	defer os.RemoveAll(tempDir)
 
 	vaultDataDir := filepath.Join(tempDir, "vault-data")
-	os.MkdirAll(vaultDataDir, 0755)
+	os.MkdirAll(vaultDataDir, 0o755)
 
 	// Create Vault configuration file
 	configPath := filepath.Join(tempDir, "vault.hcl")
@@ -61,7 +61,7 @@ listener "tcp" {
 # CACHE_BACKEND=redis for Redis, or omit for LRU
 `, vaultDataDir)
 
-	err = os.WriteFile(configPath, []byte(configContent), 0644)
+	err = os.WriteFile(configPath, []byte(configContent), 0o644)
 	if err != nil {
 		log.Fatalf("Failed to write config file: %v", err)
 	}

--- a/vault/policy_store.go
+++ b/vault/policy_store.go
@@ -16,9 +16,9 @@ import (
 	"github.com/armon/go-metrics"
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-secure-stdlib/strutil"
-	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/openbao/openbao/helper/identity"
 	"github.com/openbao/openbao/helper/namespace"
+	"github.com/openbao/openbao/sdk/v2/helper/cache"
 	"github.com/openbao/openbao/sdk/v2/logical"
 )
 
@@ -153,7 +153,7 @@ var (
 type PolicyStore struct {
 	core *Core
 
-	tokenPoliciesLRU *lru.TwoQueueCache[string, *Policy]
+	tokenPoliciesCache cache.CacheBackend[string, *Policy]
 
 	// This is used to ensure that writes to the store (acl) or to the egp
 	// path tree don't happen concurrently. We are okay reading stale data so
@@ -189,8 +189,12 @@ func NewPolicyStore(ctx context.Context, core *Core, baseView BarrierView, syste
 	}
 
 	if !system.CachingDisabled() {
-		cache, _ := lru.New2Q[string, *Policy](policyCacheSize)
-		ps.tokenPoliciesLRU = cache
+		cacheBackend, err := cache.NewCacheBackend[string, *Policy](policyCacheSize)
+		if err != nil {
+			logger.Warn("failed to create cache backend, falling back to no cache", "error", err)
+		} else {
+			ps.tokenPoliciesCache = cacheBackend
+		}
 	}
 
 	aclView := ps.getACLView(namespace.RootNamespace)
@@ -255,8 +259,8 @@ func (ps *PolicyStore) invalidate(ctx context.Context, name string, policyType P
 	// can happen is we load again if something since added it
 	switch policyType {
 	case PolicyTypeACL:
-		if ps.tokenPoliciesLRU != nil {
-			ps.tokenPoliciesLRU.Remove(index)
+		if ps.tokenPoliciesCache != nil {
+			ps.tokenPoliciesCache.Remove(index)
 		}
 
 	default:
@@ -361,8 +365,8 @@ func (ps *PolicyStore) setPolicyInternal(ctx context.Context, p *Policy, casVers
 
 		ps.policyTypeMap.Store(index, PolicyTypeACL)
 
-		if ps.tokenPoliciesLRU != nil {
-			ps.tokenPoliciesLRU.Add(index, p)
+		if ps.tokenPoliciesCache != nil {
+			ps.tokenPoliciesCache.Set(index, p)
 		}
 	default:
 		return errors.New("unknown policy type, cannot set")
@@ -423,15 +427,15 @@ func (ps *PolicyStore) switchedGetPolicy(ctx context.Context, name string, polic
 	name = ps.sanitizeName(name)
 	index := ps.cacheKey(ns, name)
 
-	var cache *lru.TwoQueueCache[string, *Policy]
+	var cache cache.CacheBackend[string, *Policy]
 	var view BarrierView
 
 	switch policyType {
 	case PolicyTypeACL:
-		cache = ps.tokenPoliciesLRU
+		cache = ps.tokenPoliciesCache
 		view = ps.getACLView(ns)
 	case PolicyTypeToken:
-		cache = ps.tokenPoliciesLRU
+		cache = ps.tokenPoliciesCache
 		val, ok := ps.policyTypeMap.Load(index)
 		if !ok {
 			// Doesn't exist
@@ -471,7 +475,7 @@ func (ps *PolicyStore) switchedGetPolicy(ctx context.Context, name string, polic
 			namespace: namespace.RootNamespace,
 		}
 		if cache != nil {
-			cache.Add(index, p)
+			cache.Set(index, p)
 		}
 		return p, nil
 	}
@@ -567,7 +571,7 @@ func (ps *PolicyStore) switchedGetPolicy(ctx context.Context, name string, polic
 
 	if cache != nil {
 		// Update the LRU cache
-		cache.Add(index, policy)
+		cache.Set(index, policy)
 	}
 
 	return policy, nil
@@ -665,9 +669,9 @@ func (ps *PolicyStore) switchedDeletePolicy(ctx context.Context, name string, po
 			}
 		}
 
-		if ps.tokenPoliciesLRU != nil {
+		if ps.tokenPoliciesCache != nil {
 			// Clear the cache
-			ps.tokenPoliciesLRU.Remove(index)
+			ps.tokenPoliciesCache.Remove(index)
 		}
 
 		ps.policyTypeMap.Delete(index)


### PR DESCRIPTION
In OpenBAO which is Hashicorp Vault fork, the cache implementation is hard coded with LRU cache.
https://github.com/openbao/openbao/blob/main/sdk/physical/cache.go#L80

Given that Vault is a single leader architecture with the standby forwarding to the leader, it'll help to have replicas handling reads. A distributed caching implementation 
will help towards building a solution where the standbys can be used as replicas that can handle read requests. The standbys can respond with cache entries.
Users also want flexibility in caching implementation to use.

The idea is make caching pluggable. For e.g, support others like Redis instead of lru.

In this implementation, I have modified the code to allow pluggable cache.
Here, I provide LRU as the default, but also Redis implementation based on an env variable
CACHE_BACKEND.
With this, BAO/Vault is able to work with Redis with just the env var CACHE_BACKEND set to "redis".

=================
Build:

`make dev`


=================

Sample config:

```
# Use Redis
export CACHE_BACKEND=redis
export REDIS_ADDR=localhost:6379
export REDIS_PASSWORD=your_password  # Optional
export REDIS_DB=0                    # Optional
export REDIS_KEY_PREFIX=vault_cache  # Optional

# Use LRU (default)
# No environment variables needed

storage "file" {
  path = "./vault-data"
}

listener "tcp" {
  address     = "127.0.0.1:8300"
  tls_disable = 1
}

ui = false 
```

=================

Run:

```
export CACHE_BACKEND=redis
export REDIS_ADDR=localhost:6379

./bao server -dev -dev-root-token-id="dev-only-token" -config=local-test.hcl

Redis keys:
127.0.0.1:6379> KEYS *
 1) "vault:\"sys/token/id/6febe7f4b909dd3aae3f2a80be5d8c9ccb23045c\""
 2) "vault:\"sys/policy/default\""
 3) "vault:\"logical/f0de566d-fe43-9f46-daa0-75791f9d69ee/casesensitivity\""
 4) "vault:\"sys/quotas/default_rate_limit_exempt_paths_toggle\""
 5) "vault:\"logical/2fd3969e-5f0a-3ee1-5990-77316e2d33d2/967b5a0d-103e-5e6e-65df-101ad5a6538a/archive/metadata\""
 6) "vault:\"core/audit\""
```